### PR TITLE
Update GNOME runtime version to 49

### DIFF
--- a/com.mastropaolo.www.tabela.json
+++ b/com.mastropaolo.www.tabela.json
@@ -1,7 +1,7 @@
 {
     "id" : "com.mastropaolo.www.tabela",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Removes EOL message on GNOME Software